### PR TITLE
Add smithy-dafny

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Ruby](https://github.com/awslabs/smithy-ruby) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> 🚧 - Client code generation for Ruby.
 * [Kotlin](https://github.com/awslabs/smithy-kotlin) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> 🚧 - Client code generation for Kotlin.
 * [Swift](https://github.com/awslabs/smithy-swift) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> 🚧 - Client code generation for Swift.
+* [Dafny](https://github.com/awslabs/smithy-dafny) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> 🚧 - Client code generation for Dafny.
 * [Scala](https://github.com/disneystreaming/smithy4s) - Community plugin for generation of clients in Scala.
 
 ### Server Code Generators


### PR DESCRIPTION
Already added to https://smithy.io/2.0/implementations.html#client-code-generators. Hopefully it's awesome enough to qualify here too. :)

Added the "official" icon since it's supported by an Amazon team, even thought it's not "the Smithy team", but open to feedback there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
