### PR TITLE
Fix SBT Plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 ## Build tools
 * [Smithy CLI](https://github.com/smithy-lang/smithy/tree/main/smithy-cli) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> - Smithy CLI is used to build, validate, diff, and transform Smithy models.
 * [Gradle Plugin](https://github.com/smithy-lang/smithy-gradle-plugin) <img src="smithy-favicon.png" alt="(official)" title="Smithy Official" height="16px"> 🚧 - Integrates Smithy with the Gradle build system.
-* [SBT Plugin](https://disneystreaming.github.io/smithy4s/docs/overview/sbt) - Community supported plugin that integrates smithy with the SBT build system for Scala.
+* [SBT Plugin](https://disneystreaming.github.io/smithy4s/docs/overview/installation/#sbt) - Community supported plugin that integrates smithy with the SBT build system for Scala.
 
 ## Code Generators
 ### Client Code Generators


### PR DESCRIPTION
*Description of changes:*
Fixes the SBT plugin link that was linking to a page that no longer exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
