### PR TITLE
Add smithy-beam to code generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Scala](https://github.com/disneystreaming/smithy4s) - Community plugin for generation of clients/servers in Scala.
 * [Dafny](https://github.com/awslabs/smithy-dafny) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Code generation tools for the [Dafny](https://dafny.org/) verification-aware programming language.
 * [Python](https://github.com/smithy-lang/smithy-python) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Client code generation for Python.
+* [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
 
 ### Server Code Generators
 * [TypeScript](https://github.com/awslabs/smithy-typescript) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for TypeScript.
 * [Java](https://github.com/smithy-lang/smithy-java) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server code generation for Java.
 * [Rust](https://github.com/awslabs/smithy-rs) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for Rust.
 * [Scala](https://github.com/disneystreaming/smithy4s) - Community plugin for generation of clients/servers in Scala.
-
+* [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
 
 ## Learning resources
 * [Smithy Examples](https://github.com/smithy-lang/smithy-examples) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> - A collection of examples to help you get up and running with Smithy.


### PR DESCRIPTION
*Description of changes:*

Adds [smithy-beam](https://github.com/f34nk/smithy-beam) to the list of code generators.

smithy-beam is a code generator targeting BEAM languages: Erlang, Elixir, Gleam.

The generator follows the official codegen guidelines. Full support for Erlang client and server generation is available - Elixir and Gleam is coming soon.
Each language gets implemented as a separate codegens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
