### PR TITLE
Add NSmithy to code generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Dafny](https://github.com/awslabs/smithy-dafny) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Code generation tools for the [Dafny](https://dafny.org/) verification-aware programming language.
 * [Python](https://github.com/smithy-lang/smithy-python) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Client code generation for Python.
 * [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
+* [CSharp](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in CSharp
 
 ### Server Code Generators
 * [TypeScript](https://github.com/awslabs/smithy-typescript) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for TypeScript.
@@ -59,6 +60,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Rust](https://github.com/awslabs/smithy-rs) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for Rust.
 * [Scala](https://github.com/disneystreaming/smithy4s) - Community plugin for generation of clients/servers in Scala.
 * [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
+* [CSharp](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in CSharp
 
 ## Learning resources
 * [Smithy Examples](https://github.com/smithy-lang/smithy-examples) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> - A collection of examples to help you get up and running with Smithy.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Dafny](https://github.com/awslabs/smithy-dafny) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Code generation tools for the [Dafny](https://dafny.org/) verification-aware programming language.
 * [Python](https://github.com/smithy-lang/smithy-python) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Client code generation for Python.
 * [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
-* [CSharp](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in CSharp
+* [C#](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in C#.
 
 ### Server Code Generators
 * [TypeScript](https://github.com/awslabs/smithy-typescript) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for TypeScript.
@@ -60,7 +60,7 @@ Official Smithy team projects with the 🚧 icon next to them are still a work-i
 * [Rust](https://github.com/awslabs/smithy-rs) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> 🚧 - Server generator for Rust.
 * [Scala](https://github.com/disneystreaming/smithy4s) - Community plugin for generation of clients/servers in Scala.
 * [Erlang, Elixir, Gleam](https://github.com/f34nk/smithy-beam) - Community plugin for generating clients and servers targeting BEAM languages: Erlang, Elixir, Gleam
-* [CSharp](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in CSharp
+* [C#](https://github.com/thomaslaich/smithy-dotnet) - Community plugin for generation of clients/servers in C#.
 
 ## Learning resources
 * [Smithy Examples](https://github.com/smithy-lang/smithy-examples) <img src="/assets/smithy-anvil.svg" alt="(official)" title="Smithy Official" height="10px"> - A collection of examples to help you get up and running with Smithy.


### PR DESCRIPTION
*Issue #, if available:* - 

*Description of changes:*
Adds [NSmithy](https://github.com/thomaslaich/smithy-dotnet) to the list of code generators.

This is an early-stage implementation of client/server code generation in C#. The project aims to provide a native .NET experience for Smithy, with a focus on clean integration into typical .NET development workflows.

The generator follows the official Smithy code generation guidelines, although a few shortcuts have been taken at this stage to validate the overall approach and prove the concept.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
